### PR TITLE
Adding script to start Postgres 12 via Docker, and utility function

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -9,3 +9,10 @@ function kill-existing() {
     docker kill "$image_name" 2>/dev/null || echo "Nothing to kill"
     docker rm "$image_name" 2>/dev/null || echo "Nothing to remove"
 }
+
+function create-network-if-needed() {
+    NETWORK_NAME="$1"
+    if [ -z $(docker network ls --filter name=^${NETWORK_NAME}$ --format="{{ .Name }}") ] ; then 
+         docker network create ${NETWORK_NAME} ; 
+    fi
+}

--- a/run-postgresql-12.sh
+++ b/run-postgresql-12.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
+source "$SOURCE_DIR/common.sh"
+
+CONTAINER_NAME=pgsql-12-metabase
+DB_NAME=metabase
+DB_USER=metabase
+DB_PASSWORD=Password1234
+HOST_PORT=${PSGQL_PORT:-5432}
+DATA_DIR=${PGSQL_DATA_DIR:-$HOME/metabase-pgsql-data}
+DOCKER_NETWORK=psql-metabase-network
+
+kill-existing $CONTAINER_NAME
+create-network-if-needed $DOCKER_NETWORK
+
+docker run \
+       --rm \
+       -d \
+       -p $HOST_PORT:5432 \
+       --network $DOCKER_NETWORK \
+       -e POSTGRES_USER=$DB_USER \
+       -e POSTGRES_DB=$DB_NAME \
+       -e POSTGRES_PASSWORD=$DB_PASSWORD \
+       -e PGDATA=/var/lib/postgresql/data \
+       -v $DATA_DIR:/var/lib/postgresql/data:Z \
+       --name $CONTAINER_NAME \
+       postgres:12
+
+cat << EOF
+Started PostgreSQL 12 port $HOST_PORT via Docker (container name: $CONTAINER_NAME). Data will be persisted in $DATA_DIR on the host machine (delete it to reset).
+
+JDBC URL: jdbc:postgres://localhost:$HOST_PORT/$DB_NAME?user=$DB_USER
+
+Environment variables for Metabase (to use as app DB):
+MB_DB_TYPE=postgres MB_DB_DBNAME=$DB_NAME MB_DB_HOST=localhost MB_DB_PASS=$DB_PASSWORD MB_DB_PORT=$HOST_PORT MB_DB_USER=$DB_USER MB_POSTGRES_TEST_USER=$DB_USER
+
+To open a SQL client session:
+docker run -it --rm --network $DOCKER_NETWORK postgres:12 psql -h $CONTAINER_NAME -U $DB_USER
+And enter the DB user password for $DB_USER: $DB_PASSWORD
+EOF


### PR DESCRIPTION
Adding a new script that starts Postgres 12 via Docker.

- As with other scripts, existing container with the same name is removed if it exists.
- At the end, the script will output some useful information
- Some environment variables can be overridden:
  - `PGSQL_PORT` - the port that will be opened on the host machine for the Postgres DB (the first value to the `-p` option of `docker run`).  Defaults to the default Postgres port, which is `5432`.
  - `PGSQL_DATA_DIR` - the path to a directory on the host disk where the Postgres DB data will be persisted (passed as a volume mapping to Docker).  Defaults to `$HOME/metabase-pgsql-data`.  Will be created by Docker if it doesn't exist, and can be deleted if data needs to be wiped out.