### PR TITLE
Add head stacks

### DIFF
--- a/run-head-mysql.sh
+++ b/run-head-mysql.sh
@@ -1,0 +1,5 @@
+docker rmi metabase/metabase-head:latest
+
+cd stacks/metabase-head-mysql
+
+docker-compose up

--- a/run-head-postgres.sh
+++ b/run-head-postgres.sh
@@ -1,0 +1,5 @@
+docker rmi metabase/metabase-head:latest
+
+cd stacks/metabase-head-postgres
+
+docker-compose up

--- a/stacks/metabase-head-mysql/docker-compose.yml
+++ b/stacks/metabase-head-mysql/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.7'
+services:
+  metabase-head:
+    # image: metabase/metabase-enterprise-head:latest
+    image: metabase/metabase-head:latest
+    container_name: metabase-head
+    hostname: metabase-head
+    volumes: 
+    - /dev/urandom:/dev/random:ro
+    ports:
+      - 3000:3000
+    networks:
+      - metanet1
+    environment: 
+      - "MB_DB_DBNAME=metabase"
+      - "MB_DB_PORT=3306"
+      - "MB_DB_USER=metabase"
+      - "MB_DB_PASS=mysecretpassword"
+      - "MB_DB_HOST=mysql-head"
+      - "MB_DB_TYPE=mysql"
+  mysql-head:
+    image: mysql:8.0.21
+    # image: mysql:5.7.32
+    container_name: mysql-head
+    hostname: mysql-head
+    ports: 
+      - 3306:3306
+    environment:
+      - "MYSQL_ROOT_PASSWORD=mysecretpassword"
+      - "MYSQL_USER=metabase"
+      - "MYSQL_PASSWORD=mysecretpassword"
+      - "MYSQL_DATABASE=metabase"
+    command: ['--default-authentication-plugin=mysql_native_password']
+    networks: 
+      - metanet1
+  sample-postgres-head:
+    image: metabase/qa-databases:postgres-sample-12
+    container_name: postgres-sample-database-head
+    hostname: postgres-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+  sample-mysql-head:
+    image: metabase/qa-databases:mysql-sample-8
+    container_name: mysql-sample-database-head
+    hostname: mysql-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+  sample-mongo-head:
+    image: metabase/qa-databases:mongo-sample-4.0
+    container_name: mongo-sample-database-head
+    hostname: mongo-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+networks: 
+  metanet1:
+    driver: bridge

--- a/stacks/metabase-head-postgres/docker-compose.yml
+++ b/stacks/metabase-head-postgres/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.7'
+services:
+  metabase-head:
+    # image: metabase/metabase-enterprise-head:latest
+    image: metabase/metabase-head:latest
+    container_name: metabase-head
+    hostname: metabase-head
+    volumes: 
+    - /dev/urandom:/dev/random:ro
+    - /$PWD/h2:/metabase.db
+    ports:
+      - 3000:3000
+    networks:
+      - metanet1
+    environment: 
+      - "MB_DB_TYPE=postgres"
+      - "MB_DB_DBNAME=metabase"
+      - "MB_DB_PORT=5432"
+      - "MB_DB_USER=metabase"
+      - "MB_DB_PASS=mysecretpassword"
+      - "MB_DB_HOST=postgres-head"
+  postgres-head:
+    image: postgres:13.1
+    container_name: postgres-head
+    hostname: postgres-head
+    # ports: 
+    #   - 5432:5432
+    environment:
+      - "POSTGRES_USER=metabase"
+      - "POSTGRES_DB=metabase"
+      - "POSTGRES_PASSWORD=mysecretpassword"
+    networks: 
+      - metanet1
+  sample-postgres-head:
+    image: metabase/qa-databases:postgres-sample-12
+    container_name: postgres-sample-database-head
+    hostname: postgres-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+  sample-mysql-head:
+    image: metabase/qa-databases:mysql-sample-8
+    container_name: mysql-sample-database-head
+    hostname: mysql-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+  sample-mongo-head:
+    image: metabase/qa-databases:mongo-sample-4.0
+    container_name: mongo-sample-database-head
+    hostname: mongo-sample-database-head
+    # ports: 
+    #   - 5432:5432
+    networks: 
+      - metanet1
+networks: 
+  metanet1:
+    driver: bridge


### PR DESCRIPTION
Adding metabase-head stacks for testing:
1) metabase w/ postgresql 13
2) metabase w/ mysql 8

both images with sample databases of postgre, mysql and mongo