### PR TITLE
Replace 127.0.0.1 with localhost for MySQL CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jdbc:mysql://localhost:3306/metabase_test?user=root
 
 MB_DB_TYPE=mysql MB_DB_DBNAME=metabase_test MB_DB_HOST=localhost MB_DB_PASS='' MB_DB_PORT=3306 MB_DB_USER=root MB_MYSQL_TEST_USER=root
 
-mysql --user=root --host=127.0.0.1 --port=3306 --database=metabase_test
+mysql --user=root --host=localhost --port=3306 --database=metabase_test
 ```
 
 You need to have Docker installed to use these scripts!

--- a/run-mariadb-latest.sh
+++ b/run-mariadb-latest.sh
@@ -41,6 +41,6 @@ or add a profile for it to your ~/.clojure/deps.edn:
 
 Connect with the MySQL CLI tool:
 
-mysql --user=root --host=127.0.0.1 --port=3306 --database=metabase_test
+mysql --user=root --host=localhost --port=3306 --database=metabase_test
 
 EOF

--- a/run-mysql-5-7.sh
+++ b/run-mysql-5-7.sh
@@ -34,6 +34,6 @@ or add a profile for it to your ~/.clojure/deps.edn:
 
 Connect with the MySQL CLI tool:
 
-mysql --user=root --host=127.0.0.1 --port=3307 --database=circle_test
+mysql --user=root --host=localhost --port=3307 --database=circle_test
 
 EOF


### PR DESCRIPTION
Using 127.0.0.1 has the host for mysql didn't work for me locally. It should be localhost.