### PR TITLE
Better watch-ci task

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -83,21 +83,11 @@
                                                  :choices-doc "list of branches"
                                                  :prompt :select})
                     branch (if (= "current" branch)
-                             (let [current (str/trim
-                                             (:out (shell {:dir (t/env "MB_DIR" (fn []
-                                                                                  (println "Please set MB_DIR to your metabase repo!")
-                                                                                  (System/exit 1))) :out :string}
-                                                          "git rev-parse --abbrev-ref HEAD")))]
-                               (do (println (c/green (c/bold "Checking current branch: " current)))
+                             (let [current (t/current-branch)]
+                               (do (println (c/green (c/bold "Using current branch: " (t/current-branch))))
                                    current))
                              branch)]
-                (pp/pprint dl/pretty)
-                (loop []
-                  (let [check (dl/checks-for-branch branch)]
-                    (print (str "\n[ " (.format (java.text.SimpleDateFormat. "hh:mm:ss a") (java.util.Date.)) " ]"))
-                    (doseq [[status count] check] (print (str/join (repeat count (dl/pretty status)))) (print "|")) (flush)
-                    (when-not (= (keys check) [:success])
-                      (Thread/sleep 10000) (recur))))))}
+                (bb.watch-ci/branch branch)))}
 
          install-autotab {:doc "Prints shell code to autocomplete tasks using bb.
                         Note: for fish shell please make sure ~/.config/fish/completions exists."

--- a/bb.edn
+++ b/bb.edn
@@ -69,7 +69,7 @@
 
          watch-ci
          {:requires [[bb.dl-and-run :as dl]
-                     [clojure.pprint :as pp]]
+                     [bb.watch-ci :as watch-ci]]
           :doc "Watch the CI status for a branch until it passes."
           :examples [["bb watch-ci --branch current" "Check currently checked out branch in MB_DIR repo"]]
           :task
@@ -79,7 +79,7 @@
                                                  :msg "What branch should we check?"
                                                  :short "-b"
                                                  :long "--branch BRANCH"
-                                                 :choices (delay (t/list-branches (t/mb-env)))
+                                                 :choices (delay (t/list-branches (t/mb-dir)))
                                                  :choices-doc "list of branches"
                                                  :prompt :select})
                     branch (if (= "current" branch)
@@ -87,7 +87,7 @@
                                (do (println (c/green (c/bold "Using current branch: " (t/current-branch))))
                                    current))
                              branch)]
-                (bb.watch-ci/branch branch)))}
+                (watch-ci/branch branch)))}
 
          install-autotab {:doc "Prints shell code to autocomplete tasks using bb.
                         Note: for fish shell please make sure ~/.config/fish/completions exists."

--- a/bb/dl_and_run.clj
+++ b/bb/dl_and_run.clj
@@ -6,7 +6,6 @@
    [bb.tasks :as t]
    [cheshire.core :as json]
    [clojure.edn :as edn]
-   [clojure.string :as str]
    [selmer.parser :refer [<<]]))
 
 (defn- keep-first
@@ -14,7 +13,7 @@
   [f coll]
   (reduce (fn [_ element] (when-let [resp (f element)] (reduced resp))) nil coll))
 
-(defn- gh-get [url]
+(defn gh-get [url]
   (try (-> url
            (curl/get {:headers {"Accept" "application/vnd.github+json"
                                 "Authorization" (str "Bearer " (t/env "GH_TOKEN"))}})
@@ -141,20 +140,3 @@
 (defn download-and-run-latest-jar! [{:keys [branch port socket-repl] :as args}]
   (let [info (download-latest-jar! args)]
     (run-jar! info port socket-repl)))
-
-(def pretty {:success "✅"
-             :skipped "⏭️ "
-             :cancelled "⏹️"
-             :in-progress "🔄"
-             :failure "❌"})
-
-(defn checks-for-branch [branch]
-  ;; note: this is a ref, so it can e.g. also be a sha.
-  (->> (str "https://api.github.com/repos/metabase/metabase/commits/" branch "/check-runs")
-       gh-get
-       :check_runs
-       (mapv :conclusion)
-       (mapv (fn [x] (if (nil? x) :in-progress (keyword x))))
-       frequencies
-       (sort-by first)
-       reverse))

--- a/bb/quick_test.clj
+++ b/bb/quick_test.clj
@@ -6,12 +6,12 @@
    [bb.tasks :as t]
    [clojure.string :as str]))
 
-(defn- test-path [] (str (t/mb-env) "/test"))
+(defn- test-path [] (str (t/mb-dir) "/test"))
 
 (defn- file->ns [path]
   (-> path
       str
-      (str/replace (str (t/mb-env) "/test/") "")
+      (str/replace (str (t/mb-dir) "/test/") "")
       (str/replace #"\.clj$" "")
       (str/replace "_" "-")
       (str/replace "/" ".")))

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -61,7 +61,7 @@
        (print (c/white "="))
        (println (c/cyan value))))))
 
-(defn mb-env []
+(defn mb-dir []
   (env "MB_DIR" (fn []
                   (println (c/red "Please put the path of your metabase repository into the MB_DIR env variable like so:"))
                   (println (c/white "export MB_DIR=path/to/metabase"))
@@ -99,3 +99,10 @@
         _ (bencode/write-bencode out {"op" "eval" "code" expr})
         bytes (get (bencode/read-bencode in) "value")]
     (String. bytes)))
+
+(defn current-branch
+  "Returns current metabase repo branch, as given by MB_DIR"
+  []
+  (str/trim
+    (:out (shell {:dir (mb-dir) :out :string}
+                 "git rev-parse --abbrev-ref HEAD"))))

--- a/bb/watch_ci.clj
+++ b/bb/watch_ci.clj
@@ -1,11 +1,6 @@
 (ns bb.watch-ci
-  (:require [babashka.process :refer [shell]]
-            [bask.colors :as c]
-            [bb.cli :as cli]
-            [bb.tasks :as t]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [bb.dl-and-run :as dl]
-            [clojure.pprint :as pp]
             [table.core :as table]))
 
 (defn checks-for-branch [branch]

--- a/bb/watch_ci.clj
+++ b/bb/watch_ci.clj
@@ -1,0 +1,49 @@
+(ns bb.watch-ci
+  (:require [babashka.process :refer [shell]]
+            [bask.colors :as c]
+            [bb.cli :as cli]
+            [bb.tasks :as t]
+            [clojure.string :as str]
+            [bb.dl-and-run :as dl]
+            [clojure.pprint :as pp]
+            [table.core :as table]))
+
+(defn checks-for-branch [branch]
+  (->> (str "https://api.github.com/repos/metabase/metabase/commits/" branch "/check-runs")
+       dl/gh-get
+       :check_runs
+       (mapv #(select-keys % [:conclusion :name :html_url]))
+       (mapv #(update % :conclusion (fnil keyword "in-progress")))
+       (sort-by :conclusion)))
+
+(defn tc [color & s]
+  (let [cm {:bold 1
+            :gray 30 :grey 30 :red 31 :green 32 :yellow 33
+            :blue 34 :magenta 35 :cyan 36 :white 37
+            :on-gray 40 :on-grey 40 :on-red 41 :on-green 42 :on-yellow 43
+            :on-blue 44 :on-magenta 45 :on-cyan 46 :on-white 47}]
+    (if-let [c (get cm color)]
+      (str "[" c "m" (str/join s) "\033[0m")
+      (str/join s))))
+
+(defn colorize-line [line]
+  (or (first (for [[re color] [[#"success" :green] [#"in-progress" :cyan] [#"failure" :red] [#"skipped" :yellow]]
+                   :when (re-find re line)]
+               (tc color line)))
+      line))
+
+(defn branch [branch]
+  (loop []
+    (let [checks (checks-for-branch branch)]
+      (println (tc :red (tc :bold branch)) (str "[ " (.format (java.text.SimpleDateFormat. "hh:mm:ss a") (java.util.Date.)) " ]"))
+      (->> (table/table-str checks)
+           str/split-lines
+           (map colorize-line)
+           (str/join "\n")
+           println)
+      (if (= #{:success} (set (map :conclusion checks)))
+        (do
+          (println (tc :green branch "passed."))
+          (System/exit 0))
+        (do (Thread/sleep 10000)
+            (recur))))))


### PR DESCRIPTION


Every 10 seconds, until your ci job completes succesfully, prints a color coded table with links to running tests, like so:

```
bcm-delete-internal-user-for-auditv2-rollback [ 05:38:59 PM ]
+--------------+-------------------------------------+------------------------------------------------------------------------------+
| conclusion   | name                                | html_url                                                                     |
+--------------+-------------------------------------+------------------------------------------------------------------------------+
| :in-progress | e2e-tests-slow-ee                   | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646549172 |
| :in-progress | e2e-tests-question-ee               | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646548280 |
| :in-progress | e2e-tests-onboarding-ee             | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547758 |
| :in-progress | e2e-tests-native-ee                 | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547465 |
| :in-progress | e2e-tests-joins-ee                  | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547041 |
| :in-progress | e2e-tests-dashboard-filters-ee      | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646546406 |
| :in-progress | e2e-tests-binning-ee                | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545542 |
| :in-progress | e2e-tests-admin-ee                  | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545155 |
| :in-progress | be-tests-sqlserver-2017-ee          | https://github.com/metabase/metabase/actions/runs/6857332802/job/18646248594 |
| :success     | e2e-tests-mongo-ee                  | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646549369 |
| :success     | e2e-tests-oss-subset-oss            | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646549014 |
| :success     | e2e-tests-visualizations-tabular-ee | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646548842 |
| :success     | e2e-tests-visualizations-charts-ee  | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646548656 |
| :success     | e2e-tests-sharing-ee                | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646548491 |
| :success     | e2e-tests-permissions-ee            | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646548104 |
| :success     | e2e-tests-organization-ee           | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547939 |
| :success     | e2e-tests-native-filters-ee         | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547608 |
| :success     | e2e-tests-models-ee                 | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646547301 |
| :success     | e2e-tests-filters-ee                | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646546822 |
| :success     | e2e-tests-embedding-ee              | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646546593 |
| :success     | e2e-tests-dashboard-cards-ee        | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646546233 |
| :success     | e2e-tests-dashboard-ee              | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545997 |
| :success     | e2e-tests-custom-column-ee          | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545840 |
| :success     | e2e-tests-collections-ee            | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545694 |
| :success     | e2e-tests-admin-2-ee                | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646545353 |
| :success     | e2e-tests-actions-ee                | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646544710 |
| :success     | percy-visual-regression-tests       | https://github.com/metabase/metabase/actions/runs/6857332816/job/18646544481 |
| :success     | be-tests-vertica-ee                 | https://github.com/metabase/metabase/actions/runs/6857332802/job/18646248917 |
| :success     | be-tests-sqlserver-2022-ee          | https://github.com/metabase/metabase/actions/runs/6857332802/job/18646248769 |
| :success     | be-tests-sqlite-ee                  | https://github.com/metabase/metabase/actions/runs/6857332802/job/18646248391 |
+--------------+-------------------------------------+------------------------------------------------------------------------------+
```