### PR TITLE
Startup adjustments for metabuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,26 @@ You'll need two environment variables set to use `bb run-branch`.
 for help with a task, use `-h` or `--help`.
 
     bb run-branch --help
-    
+
+#### Using metabuild with vscode
+
+To start repl that you can connect to from Visual Studio Code you can use following alias instead of the default `:nrepl`.
+
+`~/.clojure/deps.edn`
+```
+{:aliases
+ {:vsc {:extra-deps {nrepl/nrepl {:mvn/version,"1.0.0"}
+                     cider/cider-nrepl {:mvn/version,"0.28.5"}}
+        :main-opts ["-m" "nrepl.cmdline"
+                    "--middleware" "[cider.nrepl/cider-middleware]"]}}}
+```
+
+Your startup command could then look as following:
+`bb metabuild -d postgres -e dev:ee:ee-dev:drivers:drivers-dev:vsc`
+
+If you are running the app db in docker container from images in this repo you need to pass in also the correct credentials, eg. `MB_JETTY_PORT=10001 MB_DIR=path/to/your/mb/repo bb --config /path/to/this/repo/bb.edn metabuild -d postgres -u metabase -p Password1234 -e dev:ee:ee-dev:drivers:drivers-dev:vsc`
+
+#### Passing 
 
 ### Database Scripts
 

--- a/bb.edn
+++ b/bb.edn
@@ -35,7 +35,7 @@
           :examples [["FORCE_MB_DB_CONNECTION_URI=mysql://localhost:3308/metabase_test?user=root bb metabuild -d mysql"
                       "Connect to MYSQL, running against run-mariadb-latest.sh"]]
           :task (let [_ (println (c/red "Welcome to " (c/on-white (c/blue " MetaBuilder "))))
-                      {:keys [app-db user-name password extensions] :as p}
+                      {:keys [app-db user-name password extensions db-name] :as p}
                       (cli/menu! (current-task)
                                  {:id :app-db
                                   :short "-d"
@@ -45,7 +45,7 @@
                                   :prompt :select}
                                  {:id :user-name :short "-u" :long "--username USER" :default (t/whoami)}
                                  {:id :password :short "-p" :long "--pw PW" :default "password"}
-                                 {:id :extensions :short "-e" :long "--extensions EXT" :default ["dev" "ee" "ee-dev" "drivers" "drivers-dev" "cider/nrepl"] :prompt :multi}
+                                 {:id :extensions :short "-e" :long "--extensions EXT" :default ["dev" "ee" "ee-dev" "drivers" "drivers-dev" "nrepl"] :prompt :multi}
                                  {:id :db-name
                                   :short "-n"
                                   :long "--name DB_NAME"
@@ -53,7 +53,7 @@
                                   :title "Name of the database to connect to."
                                   :prompt :text})]
                   ;; (prn p)
-                  (meta/build app-db user-name password extensions))}
+                  (meta/build app-db user-name password extensions db-name))}
 
          quick-test
          {:doc "Quickly run a test against a namespace."

--- a/bb/meta.clj
+++ b/bb/meta.clj
@@ -21,13 +21,13 @@
     (println (c/green "[bb metabuild] 🔁 " (t/nrepl-eval nrepl-port repl-cmd)))
     (println (c/green "[bb metabuild] ✅ Done."))))
 
-(defn build [app-db user-name password extensions]
+(defn build [app-db user-name password extensions db-name]
   (let [env+ (assoc (t/env)
                     "MB_DB_CONNECTION_URI"
                     (or (t/env "FORCE_MB_DB_CONNECTION_URI" (constantly false))
                         (case app-db
-                          "mysql" (str "mysql://" user-name ":" password "@localhost:3306/metabase_test")
-                          "postgres" (str "postgres://" user-name ":" password "@localhost:5432/metabase")
+                          "mysql" (str "mysql://" user-name ":" password "@localhost:3306/" (or db-name "metabase_test"))
+                          "postgres" (str "postgres://" user-name ":" password "@localhost:5432/" (or db-name "metabase"))
                           "h2" "" ))
                     "MB_DB_TYPE" app-db)
         cmd (str "clj -M" (str/join (map (fn [s-or-kw] (keyword (name s-or-kw))) extensions)))]


### PR DESCRIPTION
- Respect the -n option aka app-db name.
- Modify default aliases to use `nrepl` as that is default for the metabase repo.
- Update readme for vscode users.