### PR TITLE
Add script for mongo 6.0

### DIFF
--- a/run-mongo-6.sh
+++ b/run-mongo-6.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+echo "Removing existing container..."
+
+docker kill mongo-6 2>/dev/null || echo "Nothing to kill"
+
+docker rm -fv mongo-6 2>/dev/null || echo "Nothing to remove"
+
+docker run -p 27017:27017 \
+       --name mongo-6 \
+       --rm \
+       -d mongo:6.0
+
+cat <<EOF
+
+Started MongoDB 6.0 on Port 27017.
+
+MB_MONGO_TEST_HOST=localhost MB_MONGO_TEST_PORT=27017
+
+Connect to the database with the MongoDB shell:
+
+docker exec -it mongo-6 mongosh
+
+EOF


### PR DESCRIPTION
This is a modified version of the mongo 4.2 script. I thought I'd keep around 4.2 for now since we haven't removed it. 

I jumped to 6.0 instead of 5.0 because 5.0 doesn't work on mac M1 without some configuration.