### PR TITLE
Update presto instructions for Mac to run driver tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Rather than use Docker, you can run Presto with Postgres with the following step
   connection-user=<mb-postgresql-test-user>
   connection-password=<mb-postgresql-test-password>
   ```
-- To run the presto-jdbc driver tests, you'll need to create a database `test_data` on the postgres server that <mb-postgresql-test-user> has all privileges to, and create a schema in the database "default".
+- To run the presto-jdbc driver tests, you'll need to create a database `test_data` on the postgres server that <mb-postgresql-test-user> has all privileges to, and create a schema in the database named "default".
 - Start the presto server with `/usr/local/opt/prestodb/bin/presto-server run`
 
 Alternatively, Luis has created a [Link](https://github.com/paoliniluis/metabase-presto-and-trino) for testing Presto and Trino with Docker that might work too.

--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ Rather than use Docker, you can run Presto with Postgres with the following step
 - Follow [these
   steps](https://prestodb.io/docs/current/installation/deploy-brew.html#deploy-presto-on-an-apple-silicon-mac-using-homebrew)
   to install presto using homebrew
-- Add a properties file for postgresql in `/usr/local/Cellar/prestodb/<version>/libexec/etc/catalog`, called `postgresql.properties` with the following contents:
+- Add a properties file for postgresql in `/usr/local/Cellar/prestodb/<version>/libexec/etc/catalog`, called
+  `test_data.properties` (`test_data` is the catalog name) with the following contents:
   ```
   connector.name=postgresql
-  connection-url=jdbc:postgresql://localhost:5432/test-data
+  connection-url=jdbc:postgresql://localhost:5432/test_data
   connection-user=<mb-postgresql-test-user>
   connection-password=<mb-postgresql-test-password>
   ```
+- Create a database `test_data` on the postgres server that <mb-postgresql-test-user> has all privileges to
 - Start the presto server with `/usr/local/opt/prestodb/bin/presto-server run`
 
 Alternatively, Luis has created a [Link](https://github.com/paoliniluis/metabase-presto-and-trino) for testing Presto and Trino with Docker that might work too.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Rather than use Docker, you can run Presto with Postgres with the following step
   connection-user=<mb-postgresql-test-user>
   connection-password=<mb-postgresql-test-password>
   ```
-- Create a database `test_data` on the postgres server that <mb-postgresql-test-user> has all privileges to
+- To run the presto-jdbc driver tests, you'll need to create a database `test_data` on the postgres server that <mb-postgresql-test-user> has all privileges to, and create a schema in the database "default".
 - Start the presto server with `/usr/local/opt/prestodb/bin/presto-server run`
 
 Alternatively, Luis has created a [Link](https://github.com/paoliniluis/metabase-presto-and-trino) for testing Presto and Trino with Docker that might work too.


### PR DESCRIPTION
`test_data` is the catalog used for the presto-jdbc driver tests. Additionally we assume that presto-jdbc driver tests have a schema named "default".

See
https://github.com/metabase/metabase/blob/a41d8146cb9c514ecb77c2369f52667c3466409a/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj#L143-L147

By following these updated instructions, you should be able to run presto jdbc tests without additional configuration.