### PR TITLE
Update bigquery and redshift scripts after 1password changes

### DIFF
--- a/env-bigquery.sh
+++ b/env-bigquery.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 item_data=$(op item get "driver: bigquery-cloud-sdk" --vault="Driver Development" --format=json)
 
 CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON=$(echo ${item_data} | jq -r '.fields[] | select(.label == "SERVICE_ACCOUNT_JSON").value')
-PROJECT_ID=$(echo ${CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON} | jq -r '.project_id')
+PROJECT_ID=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PROJECT_ID").value')
 
 function print-bigquery-vars() {
     cat <<EOF

--- a/env-redshift.sh
+++ b/env-redshift.sh
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
-item_data=$(op item get "Redshift (AWS)" --vault="Driver Development" --format=json)
+item_data=$(op item get "driver: redshift" --vault="Driver Development" --format=json)
 
-DB=dev
-HOST=$(echo ${item_data} | jq -r '.urls[] | select(.label == "host").href')
-PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "password").value')
-PORT=$(echo ${item_data} | jq -r '.urls[] | select(.label == "port").href')
-USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "username").value')
+DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "DB").value')
+HOST=$(echo ${item_data} | jq -r '.fields[] | select(.label == "HOST").value')
+PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PASSWORD").value')
+PORT=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PORT").value')
+USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "USER").value')
 
 function print-redshift-vars() {
     cat <<EOF

--- a/env-snowflake.sh
+++ b/env-snowflake.sh
@@ -8,7 +8,7 @@ USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "USER").value')
 ACCOUNT=$(echo ${item_data} | jq -r '.fields[] | select(.label == "ACCOUNT").value')
 PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PASSWORD").value')
 WAREHOUSE=$(echo ${item_data} | jq -r '.fields[] | select(.label == "WAREHOUSE").value')
-DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "database").value' | head -n 1)
+DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "DB").value' | head -n 1)
 PK_USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PK_USER").value')
 PK_PRIVATE_KEY=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PK_PRIVATE_KEY").value')
 


### PR DESCRIPTION
Made the following changes in the 1password vaults so that they are more consistent:
1. Rename the redshift vault to "driver: redshift"
2. Add a DB field to redshift vault
3. Move redshift HOST and PORT vars from urls section to fields section
4. Rename all redshift fields to be capitalized.
5. Rename bigquery project field to PROJECT_ID
6. Rename snowflake database field to DB