### PR TITLE
allow for workflows that export all env vars

### DIFF
--- a/_run-mariadb.sh
+++ b/_run-mariadb.sh
@@ -2,29 +2,34 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-source "$SOURCE_DIR/env-mariadb.sh"
-
 source "$SOURCE_DIR/common.sh"
+CONTAINER_NAME=mb-mariadb-db-${MARIADB_BROAD_VERSION}
 
 kill-existing ${CONTAINER_NAME}
 
-docker run -p ${HOST_PORT}:3306 \
-       -e MYSQL_DATABASE=${DB_NAME} \
-       -e MYSQL_USER=${DB_USER} \
+docker run -p 3306 \
+       -e MYSQL_DATABASE=metabase \
+       -e MYSQL_USER=mbuser \
        -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
        --name ${CONTAINER_NAME} \
        --rm \
        -d mariadb:${MARIADB_VERSION}
 
-cat <<EOF
+source ./env-mariadb.sh ${MARIADB_BROAD_VERSION}
 
-Started MariaDB ${MARIADB_VERSION} on port ${HOST_PORT}.
+function print-mariadb-vars() {
+    cat <<EOF
+Java properties:
+-Dmb.mysql.test.host=localhost -Dmb.mysql.test.port=${MB_DB_PORT} -Dmb.mysql.test.db=${MB_DB_DBNAME} -Dmb.mysql.test.user=${MB_DB_USER} -Dmb.mysql.test.password=
 
-Connect with the MySQL CLI tool:
-mysql --user=${DB_USER} --host=127.0.0.1 --port=${HOST_PORT} --database=${DB_NAME}
+Clojure pairs:
+:mb-mysql-test-host "localhost" :mb-mysql-test-port "${MB_DB_PORT}" :mb-mysql-test-db "${MB_DB_DBNAME}" :mb-mysql-test-user "${MB_DB_USER}" :mb-mysql-test-password ""
 
-JDBC URL: jdbc:mysql://localhost:${HOST_PORT}/${DB_NAME}?user=${DB_USER}
-
+Bash variables:
+MB_MYSQL_TEST_HOST=localhost MB_MYSQL_TEST_PORT=${MB_DB_PORT} MB_MYSQL_TEST_DB=${MB_DB_DBNAME}  MB_MYSQL_TEST_USER=${MB_DB_USER} MB_MYSQL_TEST_PASSWORD=''
 EOF
+}
 
-print-mariadb-vars
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    print-mariadb-vars
+fi

--- a/_run-mysql.sh
+++ b/_run-mysql.sh
@@ -2,28 +2,29 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-source "$SOURCE_DIR/env-mysql.sh"
-
 source "$SOURCE_DIR/common.sh"
+CONTAINER_NAME=mb-mysql-db-${MYSQL_BROAD_VERSION}
 
 kill-existing ${CONTAINER_NAME}
 
-docker run -p ${HOST_PORT}:3306 \
-       -e MYSQL_DATABASE=${DB_NAME} \
+docker run \
+       -p 3306 \
+       -e MYSQL_DATABASE=metabase \
+       -e MYSQL_USER=mbuser \
        -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
        --name ${CONTAINER_NAME} \
        --rm \
        -d mysql:${MYSQL_VERSION}
 
+source ./env-mysql.sh ${MYSQL_BROAD_VERSION}
+
 cat <<EOF
 
-Started MySQL ${MYSQL_VERSION} on port ${HOST_PORT}.
+Started MySQL ${MYSQL_VERSION} on port ${MB_DB_PORT}.
 
 Connect with the MySQL CLI tool:
-mysql --user=${DB_USER} --host=127.0.0.1 --port=${HOST_PORT} --database=${DB_NAME}
+mysql --user=${MB_DB_USER} --host=127.0.0.1 --port=${MB_DB_PORT} --database=${MB_DB_DBNAME}
 
-JDBC URL: jdbc:mysql://localhost:${HOST_PORT}/${DB_NAME}?user=${DB_USER}
+JDBC URL: jdbc:mysql://localhost:${MB_DB_PORT}/${MB_DB_DBNAME}?user=${MB_DB_USER}
 
 EOF
-
-print-mysql-vars

--- a/_run-postgres.sh
+++ b/_run-postgres.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-source "$SOURCE_DIR/env-postgres.sh"
-
 source "$SOURCE_DIR/common.sh"
-
+CONTAINER_NAME=mb-postgres-db-${PG_BROAD_VERSION}
 DATA_DIR=${HOME}/metabase-pgsql-${PG_VERSION}-data
 DOCKER_NETWORK=psql-metabase-network
 
@@ -13,29 +12,30 @@ kill-existing ${CONTAINER_NAME}
 create-network-if-needed ${DOCKER_NETWORK}
 
 docker run \
-       --rm \
        -d \
-       -p ${HOST_PORT}:5432 \
+       -p 5432 \
        --network ${DOCKER_NETWORK} \
-       -e POSTGRES_USER=${DB_USER} \
-       -e POSTGRES_DB=${DB_NAME} \
-       -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+       -e POSTGRES_USER=mbuser \
+       -e POSTGRES_DB=metabase \
+       -e POSTGRES_PASSWORD=password \
        -e PGDATA=/var/lib/postgresql/data \
        -v ${DATA_DIR}:/var/lib/postgresql/data:Z \
        --name ${CONTAINER_NAME} \
        postgres:${PG_VERSION}
 
-cat << EOF
+source ./env-postgres.sh ${PG_BROAD_VERSION}
 
-Started PostgreSQL ${PG_VERSION} on port ${HOST_PORT} via Docker (container name: ${CONTAINER_NAME}).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+       cat << EOF
+Started PostgreSQL ${PG_VERSION} on port ${MB_DB_PORT} via Docker (container name: ${CONTAINER_NAME}).
 Data will be persisted in ${DATA_DIR} on the host machine (delete it to reset).
 
 To open a SQL client session:
-docker run -it --rm --network ${DOCKER_NETWORK} postgres:${PG_VERSION} psql -h ${CONTAINER_NAME} -U ${DB_USER}
-And enter the DB user password for ${DB_USER}: ${DB_PASSWORD}
+docker run -it --rm --network ${DOCKER_NETWORK} postgres:${PG_VERSION} psql -h ${CONTAINER_NAME} -U ${MB_DB_USER}
+And enter the DB user password for ${MB_DB_USER}: ${MB_DB_PASS}
 
-JDBC URL: jdbc:postgres://localhost:${HOST_PORT}/${DB_NAME}?user=${DB_USER}
+JDBC URL: jdbc:postgres://localhost:${MB_DB_PORT}/${MB_DB_DBNAME}?user=${MB_DB_USER}
 
 EOF
 
-print-postgres-vars
+fi

--- a/env-mariadb.sh
+++ b/env-mariadb.sh
@@ -1,26 +1,45 @@
 #! /usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+fi
 
-set -euo pipefail
+SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
+cd "$(dirname "$0")"
 
-CONTAINER_NAME=mb-mariadb-db
-HOST_PORT=3307
-DB_NAME=metabase_test
-DB_USER=root
+if [[ $# -eq 0 ]] && [[ -z "${MARIADB_BROAD_VERSION:-}" ]]; then
+    echo "Usage: ./$(basename "$0") [latest/oldest]" >&2
+    exit 1
+fi
+container=mb-mariadb-db-${1:-$MARIADB_BROAD_VERSION}
+port=$(docker port ${container} 3306/tcp | cut -d: -f2)
+source ${SOURCE_DIR}/getenv.sh ${container} MYSQL_USER MYSQL_DATABASE
+
+export MB_DB_TYPE=mysql
+export MB_DB_DBNAME=${MYSQL_DATABASE}
+export MB_DB_HOST=127.0.0.1
+export MB_DB_PASS=
+export MB_DB_PORT=${port}
+export MB_DB_USER=${MYSQL_USER}
+
+export MB_MYSQL_TEST_USER=${MB_DB_USER}
+export MB_MYSQL_TEST_PASSWORD=
+export MB_MYSQL_TEST_DBNAME=${MYSQL_DATABASE}
+export MB_MYSQL_TEST_HOST=${MB_DB_HOST}
+export MB_MYSQL_TEST_PORT=${MB_DB_PORT}
 
 function print-mariadb-vars() {
     cat <<EOF
 Java properties:
--Dmb.mysql.test.host=localhost -Dmb.mysql.test.port=${HOST_PORT} -Dmb.mysql.test.db=${DB_NAME} -Dmb.mysql.test.user=${DB_USER} -Dmb.mysql.test.password=
+-Dmb.mysql.test.host=localhost -Dmb.mysql.test.port=${MB_DB_PORT} -Dmb.mysql.test.db=${MB_DB_DBNAME} -Dmb.mysql.test.user=${MB_DB_USER} -Dmb.mysql.test.password=
 
 Clojure pairs:
-:mb-mysql-test-host "localhost" :mb-mysql-test-port "${HOST_PORT}" :mb-mysql-test-db "${DB_NAME}" :mb-mysql-test-user "${DB_USER}" :mb-mysql-test-password ""
+:mb-mysql-test-host "localhost" :mb-mysql-test-port "${MB_DB_PORT}" :mb-mysql-test-db "${MB_DB_DBNAME}" :mb-mysql-test-user "${MB_DB_USER}" :mb-mysql-test-password ""
 
 Bash variables:
-MB_MYSQL_TEST_HOST=localhost MB_MYSQL_TEST_PORT=${HOST_PORT} MB_MYSQL_TEST_DB=${DB_NAME}  MB_MYSQL_TEST_USER=${DB_USER} MB_MYSQL_TEST_PASSWORD=''
+MB_MYSQL_TEST_HOST=localhost MB_MYSQL_TEST_PORT=${MB_DB_PORT} MB_MYSQL_TEST_DB=${MB_DB_DBNAME}  MB_MYSQL_TEST_USER=${MB_DB_USER} MB_MYSQL_TEST_PASSWORD=''
 EOF
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     print-mariadb-vars
 fi
-

--- a/env-mysql.sh
+++ b/env-mysql.sh
@@ -1,26 +1,45 @@
 #! /usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+fi
+SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
+cd "$(dirname "$0")"
 
-set -euo pipefail
+if [[ $# -eq 0 ]] && [[ -z "${MYSQL_BROAD_VERSION:-}" ]]; then
+    echo "Usage: ./$(basename "$0") [latest/oldest]" >&2
+    exit 1
+fi
 
-CONTAINER_NAME=mb-mysql-db
-HOST_PORT=3306
-DB_NAME=metabase_test
-DB_USER=root
+container=mb-mysql-db-${1:-$MYSQL_BROAD_VERSION}
+port=$(docker port ${container} 3306/tcp | cut -d: -f2)
+source ${SOURCE_DIR}/getenv.sh ${container} MYSQL_DATABASE MYSQL_USER
+
+export MB_DB_TYPE=mysql
+export MB_DB_DBNAME=${MYSQL_DATABASE}
+export MB_DB_HOST=127.0.0.1
+export MB_DB_PASS=
+export MB_DB_PORT=${port}
+export MB_DB_USER=${MYSQL_USER}
+
+export MB_MYSQL_TEST_USER=${MB_DB_USER}
+export MB_MYSQL_TEST_PASSWORD=
+export MB_MYSQL_TEST_DBNAME=${MYSQL_DATABASE}
+export MB_MYSQL_TEST_HOST=${MB_DB_HOST}
+export MB_MYSQL_TEST_PORT=${MB_DB_PORT}
 
 function print-mysql-vars() {
     cat <<EOF
 Java properties:
--Dmb.mysql.test.host=localhost -Dmb.mysql.test.port=${HOST_PORT} -Dmb.mysql.test.db=${DB_NAME} -Dmb.mysql.test.user=${DB_USER} -Dmb.mysql.test.password=
+-Dmb.mysql.test.host=localhost -Dmb.mysql.test.port=${MB_DB_PORT} -Dmb.mysql.test.db=${MB_DB_DBNAME} -Dmb.mysql.test.user=${MB_DB_USER} -Dmb.mysql.test.password=
 
 Clojure pairs:
-:mb-mysql-test-host "localhost" :mb-mysql-test-port "${HOST_PORT}" :mb-mysql-test-db "${DB_NAME}" :mb-mysql-test-user "${DB_USER}" :mb-mysql-test-password ""
+:mb-mysql-test-host "localhost" :mb-mysql-test-port "${MB_DB_PORT}" :mb-mysql-test-db "${MB_DB_DBNAME}" :mb-mysql-test-user "${MB_DB_USER}" :mb-mysql-test-password ""
 
 Bash variables:
-MB_MYSQL_TEST_HOST=localhost MB_MYSQL_TEST_PORT=${HOST_PORT} MB_MYSQL_TEST_DB=${DB_NAME}  MB_MYSQL_TEST_USER=${DB_USER} MB_MYSQL_TEST_PASSWORD=''
+MB_MYSQL_TEST_HOST=localhost MB_MYSQL_TEST_PORT=${MB_DB_PORT} MB_MYSQL_TEST_DB=${MB_DB_DBNAME}  MB_MYSQL_TEST_USER=${MB_DB_USER} MB_MYSQL_TEST_PASSWORD=''
 EOF
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     print-mysql-vars
 fi
-

--- a/env-postgres.sh
+++ b/env-postgres.sh
@@ -1,23 +1,48 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+fi
+SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
+cd "$(dirname "$0")"
 
-set -euo pipefail
+if [[ $# -eq 0 ]] && [[ -z "${PG_BROAD_VERSION:-}" ]]; then
+    echo "Usage: ./$(basename "$0") [latest/oldest]" >&2
+    exit 1
+fi
+# `oldest` or `latest`
+container=mb-postgres-db-${1:-$PG_BROAD_VERSION}
+port=$(docker port ${container} 5432/tcp | cut -d: -f2)
+source ${SOURCE_DIR}/getenv.sh ${container} POSTGRES_USER POSTGRES_DB POSTGRES_PASSWORD
 
-CONTAINER_NAME=mb-postgres-db
-HOST_PORT=${PGSQL_PORT:-5432}
-DB_NAME=metabase
-DB_USER=metabase
-DB_PASSWORD=password
+export MB_DB_TYPE=postgres
+export MB_DB_DBNAME=${POSTGRES_DB}
+export MB_DB_HOST=127.0.0.1
+export MB_DB_PASS=${POSTGRES_PASSWORD}
+export MB_DB_PORT=${port}
+export MB_DB_USER=${POSTGRES_USER}
+
+export MB_POSTGRESQL_TEST_USER=${MB_DB_USER}
+export MB_POSTGRESQL_TEST_PASSWORD=${MB_DB_PASS}
+export MB_POSTGRESQL_TEST_DBNAME=${MB_DB_DBNAME}
+export MB_POSTGRESQL_TEST_HOST=${MB_DB_HOST}
+export MB_POSTGRESQL_TEST_PORT=${MB_DB_PORT}
+
+export PGHOST=${MB_DB_HOST}
+export PGPORT=${MB_DB_PORT}
+export PGUSER=${MB_DB_USER}
+export PGPASSWORD=${MB_DB_PASS}
+export PGDATABASE=${MB_DB_DBNAME}
 
 function print-postgres-vars() {
     cat <<EOF
 Java properties:
--Dmb.postgresql.test.host=localhost -Dmb.postgresql.test.port=${HOST_PORT} -Dmb.postgresql.test.db=${DB_NAME} -Dmb.postgresql.test.user=${DB_USER} -Dmb.postgresql.test.password=${DB_PASSWORD}
+-Dmb.postgresql.test.host=localhost -Dmb.postgresql.test.port=${MB_DB_PORT} -Dmb.postgresql.test.db=${MB_DB_DBNAME} -Dmb.postgresql.test.user=${MB_DB_USER} -Dmb.postgresql.test.password=${MB_DB_PASS}
 
 Clojure pairs:
-:mb-postgresql-test-host "localhost" :mb-postgresql-test-port "${HOST_PORT}" :mb-postgresql-test-db "${DB_NAME}" :mb-postgresql-test-user "${DB_USER}" :mb-postgresql-test-password "${DB_PASSWORD}"
+:mb-postgresql-test-host "localhost" :mb-postgresql-test-port "${MB_DB_PORT}" :mb-postgresql-test-db "${MB_DB_DBNAME}" :mb-postgresql-test-user "${MB_DB_USER}" :mb-postgresql-test-password "${MB_DB_PASS}"
 
 Bash variables:
-MB_POSTGRESQL_TEST_HOST=localhost MB_POSTGRESQL_TEST_PORT=${HOST_PORT} MB_POSTGRESQL_TEST_DB=${DB_NAME}  MB_POSTGRESQL_TEST_USER=${DB_USER} MB_POSTGRESQL_TEST_PASSWORD=${DB_PASSWORD}
+MB_POSTGRESQL_TEST_HOST=localhost MB_POSTGRESQL_TEST_PORT=${MB_DB_PORT} MB_POSTGRESQL_TEST_DB=${MB_DB_DBNAME}  MB_POSTGRESQL_TEST_USER=${MB_DB_USER} MB_POSTGRESQL_TEST_PASSWORD=${MB_DB_PASS}
 EOF
 }
 

--- a/getenv.sh
+++ b/getenv.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash -euo pipefail
+
+container_name="$1"
+shift
+
+env_vars=$(docker inspect ${container_name} -f '{{range .Config.Env}}{{println .}}{{end}}')
+
+output=""
+
+for var_name in "$@"
+do
+    env_var=$(echo "$env_vars" | grep "$var_name=")
+    if [[ -z "$env_var"  ]]; then
+        echo "environment variable ${var_name} not found in the container ${container_name}" >&2
+        return 1
+    fi
+
+    export "$env_var"
+done

--- a/run-mariadb-latest.sh
+++ b/run-mariadb-latest.sh
@@ -2,4 +2,4 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-MARIADB_VERSION=latest $SOURCE_DIR/_run-mariadb.sh
+MARIADB_BROAD_VERSION=latest MARIADB_VERSION=latest $SOURCE_DIR/_run-mariadb.sh

--- a/run-mariadb-oldest.sh
+++ b/run-mariadb-oldest.sh
@@ -5,4 +5,4 @@ SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 MARIADB_VERSION=$(curl -s --request GET --url https://endoflife.date/api/mariadb.json |
 jq -r --arg today $(date +%Y%m%d) 'map(select((.eol == false) or ((.eol | gsub("-";"") | tonumber) > ($today | tonumber)))) | min_by(.cycle) | .cycle')
 
-MARIADB_VERSION=$MARIADB_VERSION $SOURCE_DIR/_run-mariadb.sh
+MARIADB_BROAD_VERSION=oldest MARIADB_VERSION=$MARIADB_VERSION $SOURCE_DIR/_run-mariadb.sh

--- a/run-mysql-latest.sh
+++ b/run-mysql-latest.sh
@@ -2,4 +2,4 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-MYSQL_VERSION=latest $SOURCE_DIR/_run-mysql.sh
+MYSQL_BROAD_VERSION=latest MYSQL_VERSION=latest $SOURCE_DIR/_run-mysql.sh

--- a/run-mysql-oldest.sh
+++ b/run-mysql-oldest.sh
@@ -5,4 +5,4 @@ SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 MYSQL_VERSION=$(curl -s --request GET --url https://endoflife.date/api/mysql.json |
 jq -r --arg today $(date +%Y%m%d) 'map(select((.eol == false) or ((.eol | gsub("-";"") | tonumber) > ($today | tonumber)))) | min_by(.cycle) | .cycle')
 
-MYSQL_VERSION=$MYSQL_VERSION $SOURCE_DIR/_run-mysql.sh
+MYSQL_BROAD_VERSION=oldest MYSQL_VERSION=$MYSQL_VERSION $SOURCE_DIR/_run-mysql.sh

--- a/run-postgres-latest.sh
+++ b/run-postgres-latest.sh
@@ -2,4 +2,4 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-PG_VERSION=latest $SOURCE_DIR/_run-postgres.sh
+PG_BROAD_VERSION=latest PG_VERSION=latest $SOURCE_DIR/_run-postgres.sh

--- a/run-postgres-oldest.sh
+++ b/run-postgres-oldest.sh
@@ -5,4 +5,4 @@ SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 PG_VERSION=$(curl -s --request GET --url https://endoflife.date/api/postgresql.json |
 jq -r --arg today $(date +%Y%m%d) 'map(select((.eol == false) or ((.eol | gsub("-";"") | tonumber) > ($today | tonumber)))) | min_by(.cycle) | .cycle')
 
-PG_VERSION=$PG_VERSION $SOURCE_DIR/_run-postgres.sh
+PG_BROAD_VERSION=oldest PG_VERSION=$PG_VERSION $SOURCE_DIR/_run-postgres.sh


### PR DESCRIPTION
loom here: https://www.loom.com/share/761bb56d52c6424d93d5cb4ea924bb53?sid=96faa314-71b6-40bb-b3d6-c7eefe798f0d

when developing locally, I really like the following flow:

- launch a new postgres db with `./run-postgres-latest.sh`

- be able to *programmatically* set the necessary env vars so that Metabase connects to that new postgres DB

- later, being able to *programmatically* switch to a different AppDB (e.g. back and forth between postgres and mariadb)

I've been using a hacky version of these dev tools for a while to accomplish that and figured I'd fix things up and push to see if this workflow appealed to anyone else.

The following scripts have changed in the exact same way for mariadb, mysql, and postgres:

First, `./run-$db-latest.sh` now sets one additional context variable: `[DATABASE]_BROAD_VERSION`. This allows us to figure out the right container for, e.g. `oldest` postgres, without worrying about whether the oldest version when you started the DB was v1 and now it's v2

Second, `./_run-$db.sh` now:
- starts the container, then
- runs `source ./env-$db.sh`, before
- spitting out a human-readable message about how to connect to the database.

Finally, `./env-$db.sh` now:

- takes a "broad version" (latest or oldest)

- pulls data *from the container itself*, reducing duplication (e.g. it figures out what the `MYSQL_DATABASE` you launched mysql with was, rather than making sure it's in sync)

- can be run two ways:
  - `./env-postgres.sh latest` spits out the old user-readable message about how to connect to postgres
  - `source ./env-postgres.sh latest` doesn't output anything - it sets env vars like `MB_DB_HOST`, `MB_DB_USER`, etc. so that your metabase backend will automatically use this AppDB.
  - (for postgres, but not mariadb/mysql, it'll also set the necessary env vars so you can run `psql` without any args and connect to the app DB)

One other change: the `docker run` commands no longer explicitly set a host port. Instead we just expose a public port, and the `./env-$db.sh` scripts use `port=$(docker port ${container} 3306/tcp | cut -d: -f2)` to figure out the appropriate host port.

Personally, I use this like so:

```
(defun metabase-mariadb-jack-in! ()
  (interactive)
  (shell-command "/Users/jds/src/dev-scripts/run-mariadb-latest.sh")
  (metabase-mariadb-jack-in "latest"))

(defun metabase-mariadb-oldest-jack-in! ()
  (interactive)
  (shell-command "/Users/jds/src/dev-scripts/run-mariadb-oldest.sh")
  (metabase-mariadb-jack-in "oldest"))

(defun metabase-mariadb-jack-in (version)
  "Connect to MariaDB and start metabase"
  (interactive)
  (ignore-errors (cider-quit))
  (metabase-reset-env!)
  (set-env-from-shell "/Users/jds/src/dev-scripts/env-mariadb.sh" version)
  (metabase-jack-in))
```

This way, in emacs, I can run `metabase-mariadb-oldest-jack-in!` and automatically:
- blow away the old `mariadb` DB and launch a new one
- set the env up to connect to the new container
- and restart cider to actually connect to it

Similarly, `(metabase-mariadb-jack-in "latest")` kills cider, sets up the env to connect to the *existing* latest mariadb container I have running, and then relaunches cider.