### PR TITLE
Re-order env vars to print more consistently

### DIFF
--- a/_run-druid.sh
+++ b/_run-druid.sh
@@ -21,7 +21,7 @@ cat <<EOF
 
 Started Druid ${DRUID_VERSION} on ports ${WEB_PORT}, ${HOST_PORT}, and 8888.
 
-Visit http://localhost:${WEB_PORT} in your browser to view the web console.
+Visit ${HOST}:${WEB_PORT} in your browser to view the web console.
 
 EOF
 

--- a/env-athena.sh
+++ b/env-athena.sh
@@ -4,21 +4,21 @@ set -euo pipefail
 
 item_data=$(op item get "driver: athena" --vault="Driver Development" --format=json)
 
-ACCESS_KEY=$(echo ${item_data} | jq -r '.fields[] | select(.label == "ACCESS_KEY").value')
 REGION=$(echo ${item_data} | jq -r '.fields[] | select(.label == "REGION").value')
 S3_STAGING_DIR=$(echo ${item_data} | jq -r '.fields[] | select(.label == "S3_STAGING_DIR").value')
+ACCESS_KEY=$(echo ${item_data} | jq -r '.fields[] | select(.label == "ACCESS_KEY").value')
 SECRET_KEY=$(echo ${item_data} | jq -r '.fields[] | select(.label == "SECRET_KEY").value')
 
 function print-athena-vars() {
     cat <<EOF
 Java properties:
--Dmb.athena.test.access.key=${ACCESS_KEY} -Dmb.athena.test.region=${REGION} -Dmb.athena.test.s3.staging.dir=${S3_STAGING_DIR} -Dmb.athena.test.secret.key=${SECRET_KEY}
+-Dmb.athena.test.region=${REGION} -Dmb.athena.test.s3.staging.dir=${S3_STAGING_DIR} -Dmb.athena.test.access.key=${ACCESS_KEY} -Dmb.athena.test.secret.key=${SECRET_KEY}
 
 Clojure pairs:
-:mb-athena-test-access-key "${ACCESS_KEY}" :mb-athena-test-region "${REGION}" :mb-athena-test-s3-staging-dir "${S3_STAGING_DIR}" :mb-athena-test-secret-key "${SECRET_KEY}"
+:mb-athena-test-region "${REGION}" :mb-athena-test-s3-staging-dir "${S3_STAGING_DIR}" :mb-athena-test-access-key "${ACCESS_KEY}" :mb-athena-test-secret-key "${SECRET_KEY}"
 
 Bash variables:
-MB_ATHENA_TEST_ACCESS_KEY=${ACCESS_KEY} MB_ATHENA_TEST_REGION=${REGION}  MB_ATHENA_TEST_S3_STAGING_DIR=${S3_STAGING_DIR} MB_ATHENA_TEST_SECRET_KEY=${SECRET_KEY}
+MB_ATHENA_TEST_REGION=${REGION}  MB_ATHENA_TEST_S3_STAGING_DIR=${S3_STAGING_DIR} MB_ATHENA_TEST_ACCESS_KEY=${ACCESS_KEY} MB_ATHENA_TEST_SECRET_KEY=${SECRET_KEY}
 EOF
 }
 

--- a/env-databricks.sh
+++ b/env-databricks.sh
@@ -4,21 +4,21 @@ set -euo pipefail
 
 item_data=$(op item get "driver: databricks" --vault="Driver Development" --format=json)
 
-CATALOG=$(echo ${item_data} | jq -r '.fields[] | select(.label == "CATALOG").value')
 HOST=$(echo ${item_data} | jq -r '.fields[] | select(.label == "HOST").value')
 HTTP_PATH=$(echo ${item_data} | jq -r '.fields[] | select(.label == "HTTP_PATH").value')
 TOKEN=$(echo ${item_data} | jq -r '.fields[] | select(.label == "TOKEN").value')
+CATALOG=$(echo ${item_data} | jq -r '.fields[] | select(.label == "CATALOG").value')
 
 function print-databricks-vars() {
     cat <<EOF
 Java properties:
--Dmb.databricks.test.catalog=${CATALOG} -Dmb.databricks.test.host=${HOST} -Dmb.databricks.test.http.path=${HTTP_PATH} -Dmb.databricks.test.token=${TOKEN}
+-Dmb.databricks.test.host=${HOST} -Dmb.databricks.test.http.path=${HTTP_PATH} -Dmb.databricks.test.token=${TOKEN} -Dmb.databricks.test.catalog=${CATALOG}
 
 Clojure pairs:
-:mb-databricks-test-catalog "${CATALOG}" :mb-databricks-test-host "${HOST}" :mb-databricks-test-http-path "${HTTP_PATH}" :mb-databricks-test-token "${TOKEN}"
+:mb-databricks-test-host "${HOST}" :mb-databricks-test-http-path "${HTTP_PATH}" :mb-databricks-test-token "${TOKEN}" :mb-databricks-test-catalog "${CATALOG}"
 
 Bash variables:
-MB_DATABRICKS_TEST_CATALOG=${CATALOG} MB_DATABRICKS_TEST_HOST=${HOST}  MB_DATABRICKS_TEST_HTTP_PATH=${HTTP_PATH} MB_DATABRICKS_TEST_TOKEN=${TOKEN}
+MB_DATABRICKS_TEST_HOST=${HOST}  MB_DATABRICKS_TEST_HTTP_PATH=${HTTP_PATH} MB_DATABRICKS_TEST_TOKEN=${TOKEN} MB_DATABRICKS_TEST_CATALOG=${CATALOG}
 EOF
 }
 

--- a/env-druid.sh
+++ b/env-druid.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+HOST=http://localhost
 CONTAINER_NAME=mb-druid-db
 WEB_PORT=8081
 HOST_PORT=8082
@@ -9,13 +10,13 @@ HOST_PORT=8082
 function print-druid-vars() {
     cat <<EOF
 Java properties:
--Dmb.druid.test.host=localhost -Dmb.druid.test.port=${HOST_PORT}
+-Dmb.druid.test.host=${HOST} -Dmb.druid.test.port=${HOST_PORT}
 
 Clojure pairs:
-:mb-druid-test-host "localhost" :mb-druid-test-port "${HOST_PORT}"
+:mb-druid-test-host "${HOST}" :mb-druid-test-port "${HOST_PORT}"
 
 Bash variables:
-MB_DRUID_TEST_HOST=localhost MB_DRUID_TEST_PORT=${HOST_PORT}
+MB_DRUID_TEST_HOST=${HOST} MB_DRUID_TEST_PORT=${HOST_PORT}
 EOF
 }
 

--- a/env-redshift.sh
+++ b/env-redshift.sh
@@ -4,22 +4,22 @@ set -euo pipefail
 
 item_data=$(op item get "driver: redshift" --vault="Driver Development" --format=json)
 
-DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "DB").value')
 HOST=$(echo ${item_data} | jq -r '.fields[] | select(.label == "HOST").value')
-PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PASSWORD").value')
 PORT=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PORT").value')
+DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "DB").value')
 USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "USER").value')
+PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PASSWORD").value')
 
 function print-redshift-vars() {
     cat <<EOF
 Java properties:
--Dmb.redshift.test.db=${DB} -Dmb.redshift.test.host=${HOST} -Dmb.redshift.test.password=${PASSWORD} -Dmb.redshift.test.port=${PORT} -Dmb.redshift.test.user=${USER}
+-Dmb.redshift.test.host=${HOST} -Dmb.redshift.test.port=${PORT} -Dmb.redshift.test.db=${DB} -Dmb.redshift.test.user=${USER} -Dmb.redshift.test.password=${PASSWORD}
 
 Clojure pairs:
-:mb-redshift-test-db "${DB}" :mb-redshift-test-host "${HOST}" :mb-redshift-test-password "${PASSWORD}" :mb-redshift-test-port "${PORT}" :mb-redshift-test-user "${USER}"
+:mb-redshift-test-host "${HOST}" :mb-redshift-test-port "${PORT}" :mb-redshift-test-db "${DB}" :mb-redshift-test-user "${USER}" :mb-redshift-test-password "${PASSWORD}"
 
 Bash variables:
-MB_REDSHIFT_TEST_DB=${DB} MB_REDSHIFT_TEST_HOST=${HOST}  MB_REDSHIFT_TEST_PASSWORD=${PASSWORD} MB_REDSHIFT_TEST_PORT=${PORT}  MB_REDSHIFT_TEST_USER=${USER}
+MB_REDSHIFT_TEST_HOST=${HOST}  MB_REDSHIFT_TEST_PORT=${PORT} MB_REDSHIFT_TEST_DB=${DB} MB_REDSHIFT_TEST_USER=${USER} MB_REDSHIFT_TEST_PASSWORD=${PASSWORD}
 EOF
 }
 

--- a/env-snowflake.sh
+++ b/env-snowflake.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 item_data=$(op item get "driver: snowflake" --vault="Driver Development" --format=json)
 
-USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "USER").value')
 ACCOUNT=$(echo ${item_data} | jq -r '.fields[] | select(.label == "ACCOUNT").value')
+USER=$(echo ${item_data} | jq -r '.fields[] | select(.label == "USER").value')
 PASSWORD=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PASSWORD").value')
 WAREHOUSE=$(echo ${item_data} | jq -r '.fields[] | select(.label == "WAREHOUSE").value')
 DB=$(echo ${item_data} | jq -r '.fields[] | select(.label == "DB").value' | head -n 1)
@@ -15,13 +15,13 @@ PK_PRIVATE_KEY=$(echo ${item_data} | jq -r '.fields[] | select(.label == "PK_PRI
 function print-snowflake-vars() {
     cat <<EOF
 Java properties:
--Dmb.snowflake.test.user=${USER} -Dmb.snowflake.test.account=${ACCOUNT} -Dmb.snowflake.test.password=${PASSWORD} -Dmb.snowflake.test.warehouse=${WAREHOUSE} -Dmb.snowflake.test.db=${DB} -Dmb.snowflake.test.pk.user=${PK_USER} -Dmb.snowflake.test.pk.private.key=${PK_PRIVATE_KEY}
+-Dmb.snowflake.test.account=${ACCOUNT} -Dmb.snowflake.test.user=${USER} -Dmb.snowflake.test.password=${PASSWORD} -Dmb.snowflake.test.warehouse=${WAREHOUSE} -Dmb.snowflake.test.db=${DB} -Dmb.snowflake.test.pk.user=${PK_USER} -Dmb.snowflake.test.pk.private.key=${PK_PRIVATE_KEY}
 
 Clojure pairs:
-:mb-snowflake-test-user "${USER}" :mb-snowflake-test-account "${ACCOUNT}" :mb-snowflake-test-password "${PASSWORD}" :mb-snowflake-test-warehouse "${WAREHOUSE}" :mb-snowflake-test-db "${DB}" :mb-snowflake-test-pk-user "${PK_USER}" :mb-snowflake-test-pk-private-key "${PK_PRIVATE_KEY}"
+:mb-snowflake-test-account "${ACCOUNT}" :mb-snowflake-test-user "${USER}" :mb-snowflake-test-password "${PASSWORD}" :mb-snowflake-test-warehouse "${WAREHOUSE}" :mb-snowflake-test-db "${DB}" :mb-snowflake-test-pk-user "${PK_USER}" :mb-snowflake-test-pk-private-key "${PK_PRIVATE_KEY}"
 
 Bash variables:
-MB_SNOWFLAKE_TEST_USER=${USER} MB_SNOWFLAKE_TEST_ACCOUNT=${ACCOUNT} MB_SNOWFLAKE_TEST_PASSWORD=${PASSWORD} MB_SNOWFLAKE_TEST_WAREHOUSE=${WAREHOUSE} MB_SNOWFLAKE_TEST_DB=${DB} MB_SNOWFLAKE_TEST_PK_USER=${PK_USER} MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY=${PK_PRIVATE_KEY}
+MB_SNOWFLAKE_TEST_ACCOUNT=${ACCOUNT} MB_SNOWFLAKE_TEST_USER=${USER} MB_SNOWFLAKE_TEST_PASSWORD=${PASSWORD} MB_SNOWFLAKE_TEST_WAREHOUSE=${WAREHOUSE} MB_SNOWFLAKE_TEST_DB=${DB} MB_SNOWFLAKE_TEST_PK_USER=${PK_USER} MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY=${PK_PRIVATE_KEY}
 EOF
 }
 


### PR DESCRIPTION
Re-orders how some env vars are printed so that they match the order that you fill them in from `/admin/databases/create`. Found this helpful while working on https://github.com/metabase/metabase/pull/53693