### PR TITLE
Update run-oracle-latest to use the arm64-compatible oracle-free image

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ mysql --user=root --host=127.0.0.1 --port=3306 --database=metabase_test
 You need to have Docker installed to use these scripts!
 
 #### For Macbook with ARM chips
-Some drivers like oracle, vertica, sqlserver, mysql (and possibly more) are currently not able to run on Apple M chips.
+Some drivers are currently not able to run on Apple M chips. If the docker image fails to start it might be arm64/M1 related.
 The work around is using colima:
 1. [Install](https://github.com/abiosoft/colima#getting-started) colima
 2. Start it with `colima start --arch x86_64 --memory 4`

--- a/_run-oracle.sh
+++ b/_run-oracle.sh
@@ -12,11 +12,11 @@ docker run -p ${HOST_PORT}:1521 \
        --name ${CONTAINER_NAME} \
        --rm \
        -e ORACLE_PASSWORD=${DB_PASSWORD} \
-       -d gvenzl/oracle-xe:${ORACLE_VERSION}
+       -d ${ORACLE_IMAGE}
 
 cat <<EOF
 
-Started Oracle Express Edition ${ORACLE_VERSION} on port ${HOST_PORT}.
+Started ${ORACLE_IMAGE} on port ${HOST_PORT}.
 Wait 10-20 seconds for it to finish starting.
 
 JDBC URL: jdbc:oracle:thin:@//localhost:${HOST_PORT}/${DB_NAME}?user=${DB_USER}&password=${DB_PASSWORD}

--- a/env-oracle.sh
+++ b/env-oracle.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 CONTAINER_NAME=mb-oracle-db
 HOST_PORT=1521
-DB_NAME=XEPDB1
+DB_NAME=$ORACLE_DB_NAME
 DB_USER=system
 DB_PASSWORD=password
 

--- a/run-oracle-latest.sh
+++ b/run-oracle-latest.sh
@@ -2,4 +2,7 @@
 
 SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 
-ORACLE_VERSION=latest $SOURCE_DIR/_run-oracle.sh
+ORACLE_DB_NAME=FREEPDB1
+ORACLE_IMAGE=gvenzl/oracle-free:latest
+
+ORACLE_DB_NAME=$ORACLE_DB_NAME ORACLE_IMAGE=$ORACLE_IMAGE $SOURCE_DIR/_run-oracle.sh

--- a/run-oracle-oldest.sh
+++ b/run-oracle-oldest.sh
@@ -5,4 +5,13 @@ SOURCE_DIR=`dirname "${BASH_SOURCE[0]}"`
 ORACLE_VERSION=$(curl -s --request GET --url https://endoflife.date/api/oracle-database.json |
 jq -r --arg today $(date +%Y%m%d) 'map(select(((.eol == false) or ((.eol | gsub("-";"") | tonumber) > ($today | tonumber))) and (.cycle | tonumber > 19))) | min_by(.cycle) | .cycle')
 
-ORACLE_VERSION=$ORACLE_VERSION $SOURCE_DIR/_run-oracle.sh
+ORACLE_DB_NAME=XEPDB1
+ORACLE_IMAGE=gvenzl/oracle-xe:${ORACLE_VERSION}
+
+if [[ $(uname -m) = arm64 ]]; then
+    echo
+    echo "WARNING: ${ORACLE_IMAGE} does not support arm64. You might need to run colima or enable emulation to run this image."
+    echo
+fi
+
+ORACLE_DB_NAME=$ORACLE_DB_NAME ORACLE_IMAGE=$ORACLE_IMAGE $SOURCE_DIR/_run-oracle.sh


### PR DESCRIPTION
Update run-oracle-latest to run the [oracle-free](https://hub.docker.com/r/gvenzl/oracle-free) image, which supports arm64 based Macs out-of-the-box, rather than the [oracle-xe](https://hub.docker.com/r/gvenzl/oracle-xe) image, which requires Colima.

AFAICT oracle-free is just a re-branding of the oracle-xe images for Oracle 23+. In fact, the `latest` tag for the [oracle-xe](https://hub.docker.com/r/gvenzl/oracle-xe) image seems to point to 21, so I think `run-oracle-latest` and `run-oracle-oldest` were actually running the same image.

Tested by running `DRIVERS=oracle clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:test/mbql` and verifying the tests all pass.

https://blogs.oracle.com/database/post/announcing-oracle-database-23ai-free-container-images-for-armbased-apple-macbook-computers